### PR TITLE
Update HttpClient.php

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -234,8 +234,8 @@ class HttpClient
         $lines   = \array_filter($lines, 'trim');
 
         foreach ($lines as $index => $line) {
-            // Remove HTTP/xxx param.
-            if (0 === $index) {
+            // Remove HTTP/xxx params.
+            if (strpos($line, ': ') === false) {
                 continue;
             }
 


### PR DESCRIPTION
Fix: PHP Notice:  Undefined offset: 1 in vendor/automattic/woocommerce/src/WooCommerce/HttpClient/HttpClient.php on line 242

This notice appears when we have few HTTP/xxx params, for example (var_dump of $lines):
array(6) {
  [0] =>
" string(22) "HTTP/1.1 100 Continue
  [2] =>
" string(21) "HTTP/1.1 201 Created
  [3] =>
" string(36) "Date: Mon, 21 Mar 2016 14:16:13 GMT
  [4] =>
" string(29) "Server: Apache/2.4.16 (Unix)
  [5] =>
" string(21) "Content-Length: 3273
  [6] =>
" string(46) "Content-Type: application/json; charset=UTF-8
}